### PR TITLE
Using new library for webcam capture so OpenCV is not required

### DIFF
--- a/live-object-detection/build.gradle
+++ b/live-object-detection/build.gradle
@@ -12,11 +12,17 @@ repositories {
     jcenter()
 }
 
+def webcamCaptureVersion = '0.3.12'
+def bridjVersion = '0.7.0'
+
 dependencies {
     implementation "ai.djl.mxnet:mxnet-model-zoo:0.3.0"
 
     implementation "org.bytedeco.javacpp-presets:opencv:4.0.1-1.4.4"
     implementation "org.bytedeco.javacpp-presets:opencv:4.0.1-1.4.4:macosx-x86_64"
+
+    compile "com.github.sarxos:webcam-capture:$webcamCaptureVersion"
+    compile "com.nativelibs4java:bridj:$bridjVersion"
 
     runtimeOnly "org.slf4j:slf4j-simple:1.7.29"
     runtimeOnly "ai.djl.mxnet:mxnet-native-auto:1.6.0"
@@ -28,7 +34,7 @@ application {
     mainClassName = System.getProperty("main", "com.examples.WebCam")
 }
 
-configure(this){
+configure(this) {
     defaultTasks "jar"
 
     apply from: file("${rootProject.projectDir}/../tools/gradle/formatter.gradle")


### PR DESCRIPTION
The sarxos-webcam library is a really convenient way to get webcam support for Java applications that doesn't require OpenCV. I think this would make it easier for other users to try out this code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
